### PR TITLE
Handle lowercase or uppercase account type string

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,7 @@ const strategy = new Strategy({
   callbackURL: config.CALLBACK_URL,
 }, (accessToken, refreshToken, profile, cb) => {
   const { displayName, emails, photos } = profile
-  const accountEmail = _.find(emails, e => e.type === 'account')
+  const accountEmail = _.find(emails, e => e.type && e.type.toLowerCase() === 'account')
   if (!accountEmail) {
     return cb(new Error(`Invalid emails returned: ${util.inspect(emails)}`))
   }


### PR DESCRIPTION
Recently I've had trouble authenticating using the g-proxy. I sometimes get an error which says

```
{"message":"Invalid emails returned: [ { value: 'christoffer@aito.ai', type: 'ACCOUNT' } ]"}
```

but sometimes it also works if I try to authenticate again.

In any case, since both `'account'` and '`ACCOUNT'` can be returned, this PR allows both with a case insensitive comparison.